### PR TITLE
Add anti-aliasing:

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,10 @@ fn main() {
 
     // Perform ray tracing
     camera.send_rays(scene.clone());
+    let anti_aliasing = true;
+    if anti_aliasing {
+        camera.anti_aliasing(4.0);
+    }
 
     camera.write_to_ppm(OUTPUT_PATH);
 

--- a/src/raytracer/ray.rs
+++ b/src/raytracer/ray.rs
@@ -9,7 +9,7 @@ use nalgebra::Vector3;
 use rand::Rng;
 
 const MAX_DEPTH: u8 = 5;
-const NUM_SECONDARY_RAYS: usize = 20;
+const NUM_SECONDARY_RAYS: usize = 25;
 #[derive(Debug, Clone)]
 pub struct Ray {
     pub origin: Point,


### PR DESCRIPTION
PR to merge anti-aliasing into `features/diffusion`:

Right now it is very simple anti aliasing, by only checking the neighboring pixels. The next version will be taking two or even four pixels away.

Usage:

Toggle AA with the boolean in main.

The float used for the function is the weight distributed to the actual pixel rendered.

The lower the number, the more the pixels around will affect the pixel rendered. (1.0 is they are all treated equally, 4.0 is the pixel rendered is being counted 4x as much as pixels surrounding).

